### PR TITLE
Change from batch processing to sequential processing

### DIFF
--- a/scripts/mozaikukun.py
+++ b/scripts/mozaikukun.py
@@ -6,7 +6,6 @@ import numpy as np
 from ultralytics import YOLO
 
 import modules.scripts as scripts
-from modules import images
 from modules.processing import process_images
 from modules.shared import opts
 
@@ -22,15 +21,23 @@ class Mozaikukun(scripts.Script):
         return "Mozaikukun"
 
     def show(self, is_img2img):
-        return True
+        return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
-        pussy = gr.Radio(label="pussy", choices=['raw', 'mosaic'], value='mosaic')
-        penis = gr.Radio(label="penis", choices=['raw', 'mosaic'], value='mosaic')
-        sex = gr.Radio(label="sex", choices=['raw', 'mosaic'], value='mosaic')
-        anus = gr.Radio(label="anus", choices=['raw', 'mosaic'], value='raw')
-        nipples = gr.Radio(label="nipples", choices=['raw', 'mosaic'], value='raw')
-        return [pussy, penis, sex, anus, nipples]
+        with gr.Accordion("Mozaikukun", open=False):
+            with gr.Row():
+                enabled = gr.Checkbox(
+                    label="Enabled",
+                    value=False,
+                    visible=True,
+                )
+            with gr.Row():
+                pussy = gr.Radio(label="pussy", choices=['raw', 'mosaic'], value='mosaic')
+                penis = gr.Radio(label="penis", choices=['raw', 'mosaic'], value='mosaic')
+                sex = gr.Radio(label="sex", choices=['raw', 'mosaic'], value='mosaic')
+                anus = gr.Radio(label="anus", choices=['raw', 'mosaic'], value='raw')
+                nipples = gr.Radio(label="nipples", choices=['raw', 'mosaic'], value='raw')
+        return [enabled, pussy, penis, sex, anus, nipples]
     
     def mosaic_process(self, input_img, pussy, penis, sex, anus, nipple):
         img = Image.fromarray(np.uint8(input_img))
@@ -56,14 +63,10 @@ class Mozaikukun(scripts.Script):
 
         return img
 
-    def run(self, p, pussy, penis, sex, anus, nipples):
-        p.do_not_save_samples = True
+    def postprocess_image(
+            self, p, pp, enabled, pussy, penis, sex, anus, nipples):
 
-        proc = process_images(p)
+        if not enabled:
+            return
 
-        for i in range(len(proc.images)):
-            ret = self.mosaic_process(proc.images[i], pussy, penis, sex, anus, nipples)
-            proc.images[i] = ret
-            images.save_image(proc.images[i], p.outpath_samples, "", proc.seed + i, proc.prompt, opts.samples_format, info= proc.info, p=p)
-
-        return proc
+        pp.image = self.mosaic_process(pp.image, pussy, penis, sex, anus, nipples)


### PR DESCRIPTION
During `batch` processing, we always want to know the intermediate results.
Currently, as we are processing mosaics in bulk at end, we have to wait for all batches to complete.
If we restart the webui in the middle of batch processing, there's also a possibility of losing the results. We do not want this.

In order to process sequentially, we need to override the `postprocess_image` method instead of the `run` method. However, to do that, we must return `AlwaysVisible` in the show method.

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/68f336bd994bed5442ad95bad6b6ad5564a5409a/modules/processing.py#L837-L840
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/68f336bd994bed5442ad95bad6b6ad5564a5409a/modules/scripts.py#L572-L575

Therefore, I have also added an option to `enable` the feature, just like with other extensions.