### PR TITLE
Unify feature/ui b/w webui, sd

### DIFF
--- a/mozaikukun_ui.py
+++ b/mozaikukun_ui.py
@@ -1,0 +1,66 @@
+import os
+import numpy as np
+import gradio as gr
+from PIL import Image
+
+import mozaikukun as moza
+from ultralytics import YOLO
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+object_detector = YOLO("yolov8x.pt")
+segmenter = YOLO(os.path.normpath(os.path.join(THIS_DIR, "myseg7.pt")))
+
+
+def mosaic_process(input_img, pussy, penis, sex, anus, nipple, margin, blur_radius, rate):
+    img = Image.fromarray(np.uint8(input_img))
+    img = img.convert("RGBA")
+
+    process_mode = {
+        "pussy": pussy,
+        "penis": penis,
+        "sex": sex,
+        "anus": anus,
+        "nipple": nipple,
+    }
+
+    result = moza.process_and_analyze_image(img, object_detector, segmenter)
+    for key in result.keys():
+        if key not in process_mode:
+            continue
+
+        for detect_obj in result[key]:
+            process_image = detect_obj.get_image(
+                process_mode.get(key, "mosaic"),
+                {"margin": margin, "blur_radius": blur_radius, "rate": float(rate)/100.0})
+            if process_image is None:
+                continue
+            img = Image.alpha_composite(img, process_image.convert("RGBA"))
+
+    return img
+
+def inputs_ui():
+    with gr.Column():
+        pussy = gr.Dropdown(label="pussy", value="mosaic", choices=['raw', 'mosaic', 'white'])
+        penis = gr.Dropdown(label="penis", value="mosaic", choices=['raw', 'mosaic', 'white'])
+        sex = gr.Dropdown(label="sex", value="mosaic", choices=['raw', 'mosaic', 'white'])
+        anus = gr.Dropdown(label="anus", value="raw", choices=['raw', 'mosaic', 'white'])
+        nipples = gr.Dropdown(label="nipples", value="raw", choices=['raw', 'mosaic', 'white'])
+    with gr.Column():
+        margin = gr.Slider(label="margin", value=5)
+        blur_radius = gr.Slider(label="blur_radius (white)", value=5)
+        rate = gr.Slider(label="rate (mosaic)", value=100, minimum=40, maximum=200)
+    return [pussy, penis, sex, anus, nipples, margin, blur_radius, rate]
+
+def full_ui():
+    with gr.Blocks() as ui:
+        with gr.Row():
+            img = gr.Image()
+            inputs = [img]
+            inputs.extend(inputs_ui())
+        with gr.Row():
+            btn = gr.Button("convert")
+        with gr.Row():
+            result = gr.Image()
+        btn.click(mosaic_process, inputs=inputs, outputs=[result])
+    return ui

--- a/scripts/mozaikukun.py
+++ b/scripts/mozaikukun.py
@@ -1,39 +1,11 @@
-import os
-from PIL import Image
-from pathlib import Path
-from collections import OrderedDict
-
 import gradio as gr
-import numpy as np
-from ultralytics import YOLO
 
 import modules.scripts as scripts
 from modules import script_callbacks
 
-from mozaikukun import process_and_analyze_image
-from mozaikukun_ui import full_ui, inputs_ui
-
-THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-
-def get_segmenter_models():
-    model_dir = Path(os.path.normpath(os.path.join(THIS_DIR, "../")))
-    model_paths = [
-        p
-        for p in model_dir.rglob("*")
-        if p.is_file() and p.suffix in (".pt", ".pth") and "myseg" in p.name
-    ]
-    models = OrderedDict()
-    for path in model_paths:
-        if path.name in models:
-            continue
-        models[path.name] = str(path)
-    return models
-
-DEFAULT_SEGMENTER = "myseg7.pt"
+from mozaikukun_ui import full_ui, inputs_ui, mosaic_process
 
 class Mozaikukun(scripts.Script):
-    object_detector = YOLO("yolov8x.pt")
-    segmenter_models = get_segmenter_models()
 
     def title(self):
         return "Mozaikukun"
@@ -49,55 +21,18 @@ class Mozaikukun(scripts.Script):
                     value=False,
                     visible=True,
                 )
+                elements = [enabled]
             with gr.Row():
-                segmenter_names = list(self.segmenter_models.keys())
-                segmenter_name = gr.Dropdown(
-                    label="Mozaikukun model",
-                    choices=segmenter_names,
-                    value=DEFAULT_SEGMENTER if DEFAULT_SEGMENTER in segmenter_names else segmenter_names[0],
-                    visible=True,
-                    type="value"
-                )
-            with gr.Row():
-                pussy = gr.Radio(label="pussy", choices=['raw', 'mosaic', 'white'], value='mosaic')
-                penis = gr.Radio(label="penis", choices=['raw', 'mosaic', 'white'], value='mosaic')
-                sex = gr.Radio(label="sex", choices=['raw', 'mosaic', 'white'], value='mosaic')
-                anus = gr.Radio(label="anus", choices=['raw', 'mosaic', 'white'], value='raw')
-                nipples = gr.Radio(label="nipples", choices=['raw', 'mosaic', 'white'], value='raw')
-        return [enabled, segmenter_name, pussy, penis, sex, anus, nipples]
-    
-    def mosaic_process(self, input_img, segmenter_name, pussy, penis, sex, anus, nipple):
-        img = Image.fromarray(np.uint8(input_img))
-        img = img.convert("RGBA")
-
-        process_mode = {
-            "pussy": pussy,
-            "penis": penis,
-            "sex": sex,
-            "anus": anus,
-            "nipple": nipple,
-        }
-
-        result = process_and_analyze_image(img, self.object_detector, YOLO(self.segmenter_models[segmenter_name]))
-        for key in result.keys():
-            if key not in process_mode:
-                continue
-
-            for detect_obj in result[key]:
-                process_image = detect_obj.get_image(process_mode.get(key))
-                if process_image is None:
-                    continue
-                img = Image.alpha_composite(img, process_image.convert("RGBA"))
-
-        return img
+                elements.extend(inputs_ui())
+        return elements
 
     def postprocess_image(
-            self, p, pp, enabled, segmenter_name, pussy, penis, sex, anus, nipples):
+            self, p, pp, enabled, *args):
 
         if not enabled:
             return
 
-        pp.image = self.mosaic_process(pp.image, segmenter_name, pussy, penis, sex, anus, nipples)
+        pp.image = mosaic_process(pp.image, *args)
 
 def on_ui_tabs():
     return (full_ui(), "Mozaikukun", "mozaikukun"),

--- a/scripts/mozaikukun.py
+++ b/scripts/mozaikukun.py
@@ -8,8 +8,10 @@ import numpy as np
 from ultralytics import YOLO
 
 import modules.scripts as scripts
+from modules import script_callbacks
 
 from mozaikukun import process_and_analyze_image
+from mozaikukun_ui import full_ui, inputs_ui
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -96,3 +98,8 @@ class Mozaikukun(scripts.Script):
             return
 
         pp.image = self.mosaic_process(pp.image, segmenter_name, pussy, penis, sex, anus, nipples)
+
+def on_ui_tabs():
+    return (full_ui(), "Mozaikukun", "mozaikukun"),
+
+script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/webui.py
+++ b/webui.py
@@ -1,62 +1,8 @@
-import numpy as np
-import gradio as gr
-from PIL import Image
+from mozaikukun_ui import full_ui
 
-import mozaikukun as moza
-from ultralytics import YOLO
-
-object_detector = YOLO("yolov8x.pt")
-segmenter = YOLO("myseg7.pt")
-
-
-def mosaic_process(input_img, pussy, penis, sex, anus, nipple, margin, blur_radius, rate):
-    img = Image.fromarray(np.uint8(input_img))
-    img = img.convert("RGBA")
-
-    process_mode = {
-        "pussy": pussy,
-        "penis": penis,
-        "sex": sex,
-        "anus": anus,
-        "nipple": nipple,
-    }
-
-    result = moza.process_and_analyze_image(img, object_detector, segmenter)
-    for key in result.keys():
-        if key not in process_mode:
-            continue
-
-        for detect_obj in result[key]:
-            process_image = detect_obj.get_image(
-                process_mode.get(key, "mosaic"),
-                {"margin": margin, "blur_radius": blur_radius, "rate": float(rate)/100.0})
-            if process_image is None:
-                continue
-            img = Image.alpha_composite(img, process_image.convert("RGBA"))
-
-    return img
-
-
-with gr.Blocks() as demo:
-    with gr.Row():
-        img = gr.Image()
-        with gr.Column():
-            pussy = gr.Dropdown(label="pussy", value="mosaic", choices=['raw', 'mosaic', 'white'])
-            penis = gr.Dropdown(label="penis", value="mosaic", choices=['raw', 'mosaic', 'white'])
-            sex = gr.Dropdown(label="sex", value="mosaic", choices=['raw', 'mosaic', 'white'])
-            anus = gr.Dropdown(label="anus", value="raw", choices=['raw', 'mosaic', 'white'])
-            nipples = gr.Dropdown(label="nipples", value="raw", choices=['raw', 'mosaic', 'white'])
-        with gr.Column():
-            margin = gr.Slider(label="margin", value=5)
-            blur_radius = gr.Slider(label="blur_radius (white)", value=5)
-            rate = gr.Slider(label="rate (mosaic)", value=100, minimum=40, maximum=200)
-    with gr.Row():
-        btn = gr.Button("convert")
-    with gr.Row():
-        result = gr.Image()
-    btn.click(mosaic_process, inputs=[img, pussy, penis, sex, anus, nipples, margin, blur_radius, rate], outputs=[result])
-
-demo.launch()
+if __name__=="__main__":
+    demo = full_ui()
+    demo.launch()
 
 """
 demo = gr.Interface(


### PR DESCRIPTION
`webui.py`で利用されていたコード部分をモジュールとして切り出して、webui, stable diffusionから共通的に利用するようにしました。
これに伴いstable diffusion側でのみ入れていたmodelの切り替え機能を
ひとまずdropして、代わりにwebuiでサポートされていたすべての機能をstable diffusionで利用できるようにしました。
また、stable diffusionのtabに`Mozaikukun`のtabを追加し、webui版同様の特定の画像に対するモザイク処理の機能が利用できるようになります。

<img width="775" alt="スクリーンショット 2023-08-15 21 23 05" src="https://github.com/sugarkwork/mozaikukun/assets/131214707/fb9bebe3-e883-41ac-a88d-2f0aa905b614">

<img width="1508" alt="スクリーンショット 2023-08-15 21 22 57" src="https://github.com/sugarkwork/mozaikukun/assets/131214707/b53e927c-5d9d-41bb-b2dc-3262dbddcab6">


